### PR TITLE
🎨 Palette: Add tooltips to TUI icon-only buttons and presets

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-11 - [Accessibility for Icon-Only Buttons and Presets in TUI]
+**Learning:** In Textual-based TUIs, icon-only buttons (like calendar 📅 or navigation arrows ◄/►) lack text context for screen readers and can be ambiguous for new users. Additionally, "preset" buttons often mask complex logic.
+**Action:** Use the `tooltip` attribute on Textual `Button` widgets to provide descriptive text for icon-only elements and to disclose the specific configuration (e.g., file patterns) associated with preset buttons, ensuring a more transparent and accessible user experience.

--- a/jetstream/tui/screens/datetime_picker.py
+++ b/jetstream/tui/screens/datetime_picker.py
@@ -212,12 +212,12 @@ class DateTimePickerScreen(ModalScreen[str | None]):
 
             with Horizontal(id="title-row"):
                 yield Label("📅  Pick Date & Time", id="picker-title")
-                yield Button("✕ Close", id="btn-close", variant="error")
+                yield Button("✕ Close", id="btn-close", variant="error", tooltip="Close")
 
             with Horizontal(id="month-nav"):
-                yield Button("◄", id="prev-month", variant="default")
+                yield Button("◄", id="prev-month", variant="default", tooltip="Previous month")
                 yield Label("", id="month-label")
-                yield Button("►", id="next-month", variant="default")
+                yield Button("►", id="next-month", variant="default", tooltip="Next month")
 
             with Horizontal(id="day-headers"):
                 for hdr in ("Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"):
@@ -232,13 +232,13 @@ class DateTimePickerScreen(ModalScreen[str | None]):
 
             with Horizontal(id="time-row"):
                 yield Label("Time:", id="time-lbl")
-                yield Button("-", id="hour-dec", classes="time-btn")
+                yield Button("-", id="hour-dec", classes="time-btn", tooltip="Decrease hour")
                 yield Label("00", id="hour-val")
-                yield Button("+", id="hour-inc", classes="time-btn")
+                yield Button("+", id="hour-inc", classes="time-btn", tooltip="Increase hour")
                 yield Label(":", id="time-sep")
-                yield Button("-", id="min-dec", classes="time-btn")
+                yield Button("-", id="min-dec", classes="time-btn", tooltip="Decrease minute")
                 yield Label("00", id="min-val")
-                yield Button("+", id="min-inc", classes="time-btn")
+                yield Button("+", id="min-inc", classes="time-btn", tooltip="Increase minute")
                 yield Button("AM", id="ampm-btn", variant="primary")
                 yield Button("12h", id="mode-btn", variant="default")
 

--- a/jetstream/tui/screens/job_create.py
+++ b/jetstream/tui/screens/job_create.py
@@ -287,7 +287,7 @@ class JobCreateScreen(Screen):
                     yield Label("Schedule For (local time, optional)", classes="field-label")
                     with Horizontal(classes="dt-input-row"):
                         yield Input(placeholder="2026-05-10T14:00:00", id="scheduled-for")
-                        yield Button("📅", id="btn-pick-dt", variant="default")
+                        yield Button("📅", id="btn-pick-dt", variant="default", tooltip="Open date/time picker")
 
                 with Horizontal(classes="switch-pair"):
                     with Vertical():
@@ -304,11 +304,11 @@ class JobCreateScreen(Screen):
                 yield Label("─ FILE FILTERING ─", classes="col-head")
 
                 with Horizontal(id="preset-row"):
-                    yield Button("🗑️ Temp",    id="preset-temp",   classes="preset-btn", variant="default")
-                    yield Button("💻 System",  id="preset-system", classes="preset-btn", variant="default")
-                    yield Button("🐟 PIFSC",   id="preset-pifsc",  classes="preset-btn", variant="default")
-                    yield Button("🚫 No RAW",  id="preset-noraw",  classes="preset-btn", variant="default")
-                    yield Button("❌ Clear",   id="preset-clear",  classes="preset-btn", variant="error")
+                    yield Button("🗑️ Temp",    id="preset-temp",   classes="preset-btn", variant="default", tooltip="Exclude temporary and backup files (*.tmp, *.bak, *.swp, ~$*, Thumbs.db, desktop.ini)")
+                    yield Button("💻 System",  id="preset-system", classes="preset-btn", variant="default", tooltip="Exclude system and version control folders (.git, .svn, __pycache__, etc.)")
+                    yield Button("🐟 PIFSC",   id="preset-pifsc",  classes="preset-btn", variant="default", tooltip="PIFSC standard exclusions (includes _archive, MISC, DARK, Products folders)")
+                    yield Button("🚫 No RAW",  id="preset-noraw",  classes="preset-btn", variant="default", tooltip="Exclude camera RAW files (*.ARW, *.NEF, *.CR2, etc.)")
+                    yield Button("❌ Clear",   id="preset-clear",  classes="preset-btn", variant="error", tooltip="Clear all exclusion patterns and folders")
 
                 with Vertical(classes="field-row"):
                     yield Label("Exclude Patterns (comma-separated)", classes="field-label")


### PR DESCRIPTION
Added descriptive tooltips to icon-only buttons (calendar, month navigation, time adjustments) and file exclusion presets in the TUI screens. This improves accessibility for screen readers and discoverability for users by disclosing the underlying logic of shorthand controls.

---
*PR created automatically by Jules for task [12137371759098426308](https://jules.google.com/task/12137371759098426308) started by @MichaelAkridge-NOAA*